### PR TITLE
improve test_params_have_effect.py; 2015 -> DEFAULT_START_YEAR

### DIFF
--- a/btax/parameters.py
+++ b/btax/parameters.py
@@ -13,7 +13,7 @@ import os
 import pandas as pd
 import numpy as np
 
-from btax.util import read_from_egg
+from btax.util import read_from_egg, DEFAULT_START_YEAR
 
 
 DEFAULTS = json.loads(read_from_egg(os.path.join('param_defaults', 'btax_defaults.json')))
@@ -28,7 +28,7 @@ def translate_param_names(start_year=2017,**user_mods):
 
     # btax_betr_entity_Switch # If this parameter =True, then u_nc default to corp rate
 
-    year = start_year-2015
+    year = start_year - DEFAULT_START_YEAR
     defaults = dict(DEFAULTS)
     user_mods.update({k: v['value'][year] for k,v in defaults.iteritems()
                       if k not in user_mods})
@@ -38,11 +38,11 @@ def translate_param_names(start_year=2017,**user_mods):
     class_list_str = [(str(i) if i != 27.5 else '27_5') for i in class_list]
     user_deprec_system = {}
     for cl in class_list_str:
-        if user_mods.get('btax_depr_'+cl+'yr_gds_Switch'):
+        if user_mods.get('btax_depr_{}yr_gds_Switch'.format(cl)):
             user_deprec_system[cl] = 'GDS'
-        elif user_mods.get('btax_depr_'+cl+'yr_ads_Switch'):
+        elif user_mods.get('btax_depr_{}yr_ads_Switch'.format(cl)):
             user_deprec_system[cl] = 'ADS'
-        elif user_mods.get('btax_depr_'+cl+'yr_tax_Switch'):
+        elif user_mods.get('btax_depr_{}yr_tax_Switch'.format(cl)):
             user_deprec_system[cl] = 'Economic'
         else:
             user_deprec_system[cl] = 'GDS'

--- a/btax/tests/test_params_have_effect.py
+++ b/btax/tests/test_params_have_effect.py
@@ -44,7 +44,7 @@ def tst_once(fast_or_slow, **user_params):
         # is seen from defaults
         user_params = translate_param_names(**user_params)
         default_params = translate_param_names()
-        assert user_params != default_params
+        assert user_params != default_params, repr((user_params, default_params))
 
 
 def tst_each_param_has_effect(fast_or_slow, k, v):
@@ -81,9 +81,15 @@ def tst_each_param_has_effect(fast_or_slow, k, v):
         val = default + 1
     else:
         val = default + 0.05
+    if isinstance(val, float) and val == 0.:
+        val = 0.01
     # Run it with one parameter in non-default mode
     user_mods[k] = val
-    tst_once(fast_or_slow, **user_mods)
+    try:
+        tst_once(fast_or_slow, **user_mods)
+    except:
+        print(user_mods, val)
+        raise
 
 
 @pytest.mark.parametrize('k,v', [(k,v) for k,v in DEFAULTS

--- a/btax/util.py
+++ b/btax/util.py
@@ -6,6 +6,8 @@ from pkg_resources import resource_stream, Requirement
 
 import pandas as pd
 
+DEFAULT_START_YEAR = 2015
+
 def read_from_egg(tfile):
     '''Read a relative path, getting the contents
     locally or from the installed egg, parsing the contents


### PR DESCRIPTION
At least two tests were failing because one of the parameters was being tested with a user modification of the parameter being exactly 0 (float).  Fix was to change the test value in test_params_have_effect.py to small float in these cases.