### PR TITLE
Add s3fs to environment.yml and set AWS cred default values to None

### DIFF
--- a/cs-config/cs_config/functions.py
+++ b/cs-config/cs_config/functions.py
@@ -11,8 +11,8 @@ from collections import OrderedDict
 from .helpers import retrieve_puf
 import cs2tc
 
-AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID", "")
-AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
+AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
+AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
 
 
 class MetaParams(paramtools.Parameters):

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
 - pycodestyle
 - pylint
 - coverage
+- s3fs
 - pip:
   - jupyter-book>=0.9.1
   - cs-kit


### PR DESCRIPTION
I tested locally and realized that [`s3fs`](https://github.com/dask/s3fs) wasn't installed. This PR adds that package to the `environment.yml` file. Alternatively, I could put it in the `cs-config/install.sh` file and it would only be installed on CS. Let me know what works best for you.